### PR TITLE
Feature/game state init

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="uid://d01ygggpfvijv"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
+[autoload]
+
+GameState="*res://scripts/Singletons/SkellyGameState.gd"
+
 [dotnet]
 
 project/assembly_name="spacegame"

--- a/scripts/Develop/OutputFL.gd
+++ b/scripts/Develop/OutputFL.gd
@@ -1,0 +1,7 @@
+extends Object
+
+##	Takes in a [Color] object and returns the necessary tags for print_rich text[br]
+##	Accepts [Color][br]
+##	Returns String Array [Opening color tag, closing color tag]
+static func AsRichColor (DesiredColor: Color) -> Array[String]:
+	return ["[color=" + DesiredColor.to_html() + "]", "[/color]"]

--- a/scripts/Develop/OutputFL.gd.uid
+++ b/scripts/Develop/OutputFL.gd.uid
@@ -1,0 +1,1 @@
+uid://bxb1yoowg4oiw

--- a/scripts/Singletons/SkellyGameState.gd
+++ b/scripts/Singletons/SkellyGameState.gd
@@ -1,0 +1,55 @@
+extends Node
+
+const DebugLibrary = preload("res://scripts/Develop/OutputFL.gd")
+
+enum EGameState {
+	LOADING,
+	MENU,
+	PLAYING,
+	PAUSED,
+	GAME_OVER
+}
+
+enum EInGameState {
+	NONE,
+	ASTEROID,
+	SPACE
+}
+
+var _GameState : EGameState
+var _InGameState: EInGameState
+
+signal on_world_position_changed(NewPlayerPosition : EInGameState)
+signal on_game_state_changed(NewGameState : EGameState)
+
+func GetGameState():
+	return _GameState
+
+func SetGameState(NewGameState : EGameState):
+	if _GameState != NewGameState:
+		_GameState = NewGameState
+		on_world_position_changed.emit(_GameState)
+		_OutputNotifyGameState(_GameState, Color.ORCHID)
+
+func GetInGameState():
+	return _InGameState
+	
+func SetInGameState(NewInGameState : EInGameState):
+	if _InGameState != NewInGameState:
+		_InGameState = NewInGameState
+		on_world_position_changed.emit(_InGameState)
+		_OutputNotifyInGameState(_InGameState, Color.AQUAMARINE)
+		
+static func _OutputNotifyGameState(NotifyState : EGameState, TextColor : Color) -> void:
+	var Output = DebugLibrary.AsRichColor(TextColor)
+	print_rich(Output[0] + EGameState.keys()[NotifyState] + Output[1])
+	
+static func _OutputNotifyInGameState(NotifyState : EInGameState, TextColor : Color) -> void:
+	var Output = DebugLibrary.AsRichColor(TextColor)
+	print_rich(Output[0] + EInGameState.keys()[NotifyState] + Output[1])
+	
+
+
+func _init() -> void:
+	SetGameState(EGameState.PLAYING)
+	SetInGameState(EInGameState.SPACE)

--- a/scripts/Singletons/SkellyGameState.gd.uid
+++ b/scripts/Singletons/SkellyGameState.gd.uid
@@ -1,0 +1,1 @@
+uid://coxcvqn7r7xvq


### PR DESCRIPTION
## Scope

Added a game state singleton to utilize as the project gets more complex. Not married to any values within it. Just some reasonable enums and signals that we can use for organization. Signals seem to be similar to event dispatchers so I am using them in a similar way, but please let me know if that is not correct.

## Testing

Verify that the game state is autoloading and run the main scene in editor. The output should be popping up the two enums PLAYING and SPACE. These values are hard coded for now and do not actually matter yet