### PR TITLE
Adding a controller manager to control the signals we care about

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,10 +18,75 @@ config/icon="res://icon.svg"
 [autoload]
 
 GameState="*res://scripts/Singletons/SkellyGameState.gd"
+PlayerController="*res://scripts/Singletons/Controllers/SkellyInputManager.gd"
+InputConstants="*res://scripts/Singletons/Constants/InputConstants.gd"
 
 [dotnet]
 
 project/assembly_name="spacegame"
+
+[input]
+
+skelly_input_action_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, null]
+}
+skelly_input_action_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":68,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":68,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":68,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_forward={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":87,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":87,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_backward={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":83,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":83,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_jump={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_0={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+, null]
+}
+skelly_input_action_1={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":2,"position":Vector2(182, 15),"global_position":Vector2(191, 63),"factor":1.0,"button_index":2,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
+skelly_input_action_2={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_3={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
+skelly_input_action_pause={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [physics]
 

--- a/scripts/Singletons/Constants/InputConstants.gd
+++ b/scripts/Singletons/Constants/InputConstants.gd
@@ -1,0 +1,31 @@
+extends Node
+
+
+enum InputAction {
+	DEFAULT,
+	INPUT_ACTION_LEFT,
+	INPUT_ACTION_RIGHT,
+	INPUT_ACTION_FORWARD,
+	INPUT_ACTION_BACKWARD,
+	INPUT_ACTION_JUMP,
+	INPUT_ACTION_0,
+	INPUT_ACTION_1,
+	INPUT_ACTION_2,
+	INPUT_ACTION_3,
+	INPUT_ACTION_PAUSE
+}
+
+const InputActionEnumToString = {
+	"skelly_input_action_left" 		: 	InputAction.INPUT_ACTION_LEFT,
+	"skelly_input_action_right"		: 	InputAction.INPUT_ACTION_RIGHT,
+	"skelly_input_action_forward"	:	InputAction.INPUT_ACTION_FORWARD,
+	"skelly_input_action_backward"	: 	InputAction.INPUT_ACTION_BACKWARD,
+	"skelly_input_action_jump"		:	InputAction.INPUT_ACTION_JUMP,
+	"skelly_input_action_0"			: 	InputAction.INPUT_ACTION_0,
+	"skelly_input_action_1"			:	InputAction.INPUT_ACTION_1,
+	"skelly_input_action_2"			:	InputAction.INPUT_ACTION_2,
+	"skelly_input_action_3"			:	InputAction.INPUT_ACTION_3,
+	"skelly_input_action_pause"		:	InputAction.INPUT_ACTION_PAUSE
+	
+	
+}

--- a/scripts/Singletons/Constants/InputConstants.gd
+++ b/scripts/Singletons/Constants/InputConstants.gd
@@ -15,7 +15,7 @@ enum InputAction {
 	INPUT_ACTION_PAUSE
 }
 
-const InputActionEnumToString = {
+const InputActionStringToEnum = {
 	"skelly_input_action_left" 		: 	InputAction.INPUT_ACTION_LEFT,
 	"skelly_input_action_right"		: 	InputAction.INPUT_ACTION_RIGHT,
 	"skelly_input_action_forward"	:	InputAction.INPUT_ACTION_FORWARD,

--- a/scripts/Singletons/Constants/InputConstants.gd.uid
+++ b/scripts/Singletons/Constants/InputConstants.gd.uid
@@ -1,0 +1,1 @@
+uid://0nokl8sb5yh7

--- a/scripts/Singletons/Controllers/SkellyInputManager.gd
+++ b/scripts/Singletons/Controllers/SkellyInputManager.gd
@@ -22,10 +22,11 @@ var _GameInputs : Dictionary = {}
 func _input(event: InputEvent) -> void:
 	var InputToEmit = _GameInputs.get(event.as_text())
 	if InputToEmit != null:
-		_EmitMessage(InputToEmit)
+		print(event)
+		_emit_message(InputToEmit, event)
 		
 ## Finds all input mapped inputs assuming the 'skelly' prefix and sets the _GameInputs dictionary
-func _InitializeControllerGameInputs() -> void:
+func _initialize_controller_game_inputs() -> void:
 	var InputActionArray = []
 	for MappedInput in ProjectSettings.get_property_list().filter(func(Property): return "input/skelly" in Property.name):
 		var MappedInputName = MappedInput.name.split("/")[-1]
@@ -33,45 +34,48 @@ func _InitializeControllerGameInputs() -> void:
 			var KeyInput : String
 			if InputActionEvent is InputEventKey:
 				KeyInput = OS.get_keycode_string(InputActionEvent.get_physical_keycode_with_modifiers())
-				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionEnumToString[MappedInputName])
+				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionStringToEnum[MappedInputName])
 			else:
+				#TODO: May need to update this else statement when/if gamepads are added
 				KeyInput = InputActionEvent.as_text()
-				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionEnumToString[MappedInputName])
+				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionStringToEnum[MappedInputName])
 
-func _EmitMessage(InputEnum : InputConstants.InputAction):
+## 	Emit message to subscribers. Subscribers should already now the action input, and the event will
+##	be passed to handle modifiers and states by the subscriber
+func _emit_message(InputEnum : InputConstants.InputAction, Event : InputEvent):
 	match InputEnum:
 		InputConstants.InputAction.INPUT_ACTION_LEFT:
-			_on_input_left.emit()
+			_on_input_left.emit(Event)
 			
 		InputConstants.InputAction.INPUT_ACTION_RIGHT:
-			_on_input_right.emit()
+			_on_input_right.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_FORWARD:
-			_on_input_forward.emit()
+			_on_input_forward.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_BACKWARD:
-			_on_input_backward.emit()
+			_on_input_backward.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_JUMP:
-			_on_input_jump.emit()
+			_on_input_jump.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_0:
-			_on_input_0.emit()
+			_on_input_0.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_1:
-			_on_input_1.emit()
+			_on_input_1.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_2:
-			_on_input_2.emit()
+			_on_input_2.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_3:
-			_on_input_3.emit()
+			_on_input_3.emit(Event)
 
 		InputConstants.InputAction.INPUT_ACTION_PAUSE:
-			_on_input_pause.emit()
+			_on_input_pause.emit(Event)
 
 		InputConstants.InputAction.DEFAULT:
 			print("What did you do?!?")
 
 func _init() -> void:	
-	_InitializeControllerGameInputs()
+	_initialize_controller_game_inputs()

--- a/scripts/Singletons/Controllers/SkellyInputManager.gd
+++ b/scripts/Singletons/Controllers/SkellyInputManager.gd
@@ -1,0 +1,77 @@
+extends Node
+
+class_name SkellyController
+
+const InputConstants := preload("res://scripts/Singletons/Constants/InputConstants.gd")
+
+signal _on_input_left()
+signal _on_input_right()
+signal _on_input_forward()
+signal _on_input_backward()
+signal _on_input_jump()
+signal _on_input_0()
+signal _on_input_1()
+signal _on_input_2()
+signal _on_input_3()
+signal _on_input_pause()
+
+
+
+var _GameInputs : Dictionary = {}
+
+func _input(event: InputEvent) -> void:
+	var InputToEmit = _GameInputs.get(event.as_text())
+	if InputToEmit != null:
+		_EmitMessage(InputToEmit)
+		
+## Finds all input mapped inputs assuming the 'skelly' prefix and sets the _GameInputs dictionary
+func _InitializeControllerGameInputs() -> void:
+	var InputActionArray = []
+	for MappedInput in ProjectSettings.get_property_list().filter(func(Property): return "input/skelly" in Property.name):
+		var MappedInputName = MappedInput.name.split("/")[-1]
+		for InputActionEvent in InputMap.action_get_events(MappedInputName):
+			var KeyInput : String
+			if InputActionEvent is InputEventKey:
+				KeyInput = OS.get_keycode_string(InputActionEvent.get_physical_keycode_with_modifiers())
+				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionEnumToString[MappedInputName])
+			else:
+				KeyInput = InputActionEvent.as_text()
+				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionEnumToString[MappedInputName])
+
+func _EmitMessage(InputEnum : InputConstants.InputAction):
+	match InputEnum:
+		InputConstants.InputAction.INPUT_ACTION_LEFT:
+			_on_input_left.emit()
+			
+		InputConstants.InputAction.INPUT_ACTION_RIGHT:
+			_on_input_right.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_FORWARD:
+			_on_input_forward.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_BACKWARD:
+			_on_input_backward.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_JUMP:
+			_on_input_jump.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_0:
+			_on_input_0.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_1:
+			_on_input_1.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_2:
+			_on_input_2.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_3:
+			_on_input_3.emit()
+
+		InputConstants.InputAction.INPUT_ACTION_PAUSE:
+			_on_input_pause.emit()
+
+		InputConstants.InputAction.DEFAULT:
+			print("What did you do?!?")
+
+func _init() -> void:	
+	_InitializeControllerGameInputs()

--- a/scripts/Singletons/Controllers/SkellyInputManager.gd
+++ b/scripts/Singletons/Controllers/SkellyInputManager.gd
@@ -2,8 +2,6 @@ extends Node
 
 class_name SkellyController
 
-const InputConstants := preload("res://scripts/Singletons/Constants/InputConstants.gd")
-
 signal _on_input_left()
 signal _on_input_right()
 signal _on_input_forward()
@@ -17,62 +15,62 @@ signal _on_input_pause()
 
 
 
-var _GameInputs : Dictionary = {}
+var _game_inputs : Dictionary = {}
 
 func _input(event: InputEvent) -> void:
-	var InputToEmit = _GameInputs.get(event.as_text())
-	if InputToEmit != null:
+	var input_to_emit = _game_inputs.get(event.as_text())
+	if input_to_emit != null:
 		print(event)
-		_emit_message(InputToEmit, event)
+		_emit_message(input_to_emit, event)
 		
-## Finds all input mapped inputs assuming the 'skelly' prefix and sets the _GameInputs dictionary
+## Finds all input mapped inputs assuming the 'skelly' prefix and sets the _game_inputs dictionary
 func _initialize_controller_game_inputs() -> void:
-	var InputActionArray = []
-	for MappedInput in ProjectSettings.get_property_list().filter(func(Property): return "input/skelly" in Property.name):
-		var MappedInputName = MappedInput.name.split("/")[-1]
-		for InputActionEvent in InputMap.action_get_events(MappedInputName):
-			var KeyInput : String
-			if InputActionEvent is InputEventKey:
-				KeyInput = OS.get_keycode_string(InputActionEvent.get_physical_keycode_with_modifiers())
-				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionStringToEnum[MappedInputName])
+	var input_action_array = []
+	for mapped_input in ProjectSettings.get_property_list().filter(func(Property): return "input/skelly" in Property.name):
+		var mapped_input_name = mapped_input.name.split("/")[-1]
+		for input_action_event in InputMap.action_get_events(mapped_input_name):
+			var key_input : String
+			if input_action_event is InputEventKey:
+				key_input = OS.get_keycode_string(input_action_event.get_physical_keycode_with_modifiers())
+				_game_inputs.get_or_add(key_input, InputConstants.InputActionStringToEnum[mapped_input_name])
 			else:
 				#TODO: May need to update this else statement when/if gamepads are added
-				KeyInput = InputActionEvent.as_text()
-				_GameInputs.get_or_add(KeyInput, InputConstants.InputActionStringToEnum[MappedInputName])
+				key_input = input_action_event.as_text()
+				_game_inputs.get_or_add(key_input, InputConstants.InputActionStringToEnum[mapped_input_name])
 
 ## 	Emit message to subscribers. Subscribers should already now the action input, and the event will
 ##	be passed to handle modifiers and states by the subscriber
-func _emit_message(InputEnum : InputConstants.InputAction, Event : InputEvent):
+func _emit_message(InputEnum : InputConstants.InputAction, event : InputEvent):
 	match InputEnum:
 		InputConstants.InputAction.INPUT_ACTION_LEFT:
-			_on_input_left.emit(Event)
+			_on_input_left.emit(event)
 			
 		InputConstants.InputAction.INPUT_ACTION_RIGHT:
-			_on_input_right.emit(Event)
+			_on_input_right.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_FORWARD:
-			_on_input_forward.emit(Event)
+			_on_input_forward.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_BACKWARD:
-			_on_input_backward.emit(Event)
+			_on_input_backward.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_JUMP:
-			_on_input_jump.emit(Event)
+			_on_input_jump.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_0:
-			_on_input_0.emit(Event)
+			_on_input_0.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_1:
-			_on_input_1.emit(Event)
+			_on_input_1.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_2:
-			_on_input_2.emit(Event)
+			_on_input_2.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_3:
-			_on_input_3.emit(Event)
+			_on_input_3.emit(event)
 
 		InputConstants.InputAction.INPUT_ACTION_PAUSE:
-			_on_input_pause.emit(Event)
+			_on_input_pause.emit(event)
 
 		InputConstants.InputAction.DEFAULT:
 			print("What did you do?!?")

--- a/scripts/Singletons/Controllers/SkellyInputManager.gd.uid
+++ b/scripts/Singletons/Controllers/SkellyInputManager.gd.uid
@@ -1,0 +1,1 @@
+uid://ccsnp33jkce0w


### PR DESCRIPTION
## Scope
Adding in some initial input mappings. It is all my best guess at the moment, but it should be enough to get started. Note that I am assuming a 'skelly' prefix on our custom input mappings. We can change this  whenever we decide on a good name in the future.

## Testing
No real good way to tell right now, but in the future we should hook up our actors or whatever they are called in godot to listen to these signals. Currently I have these emitting. All signals start with ' _on_input'.

- W(+shift, +ctrl) - forward
- A+shift, +ctrl) - left
- S(+shift, +ctrl) - backward
- D+shift, +ctrl) - right
- Space - Jump
- E - forward - action 2
- Q,I - action 3
- LeftMouse - action 0
- RightMouse - action 1
- P, Escape - Pause


## Future Work
- Gotta figure out if these signals actually work the way I am thinking they do. I am assuming a character or node can subscribe to these signals and perform their code when they get a specific call (character in space would rotate counter clockwise in space on an E press, but a character on an asteroid might walk left on an E press)
- I have Shift and Alt WASDs accounted for in the emits, but this is not actually supplying any information about those modifiers at the moment. There will need to be work done to account for those. An E+Shift will send the exact same signal as E.
- The **_InitializeControllerGameInputs()** function will probably need to be reworked if/when we incorporate gamepads. At the moment I am not accounting for them but I am totally open to it, they just will not emit right now. This would also include updating the input mappings